### PR TITLE
Fix Binder links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # CESM LENS on AWS Cookbook
 
 [![nightly-build](https://github.com/ProjectPythiaCookbooks/cesm-lens-aws-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythiaCookbooks/cesm-lens-aws-cookbook/actions/workflows/nightly-build.yaml)
-[![Binder](https://binder-staging.2i2c.cloud/badge_logo.svg)](https://binder-staging.2i2c.cloud/v2/gh/ProjectPythiaCookbooks/cesm-lens-aws-cookbook/main?labpath=notebooks)
+[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/ProjectPythiaCookbooks/cesm-lens-aws-cookbook/main?labpath=notebooks)
 
 This Project Pythia Cookbook covers analysis of CESM LENS data publicly available on Amazon S3 (us-west-2 region) using Xarray and Dask
 

--- a/_config.yml
+++ b/_config.yml
@@ -55,7 +55,7 @@ sphinx:
           icon: fab fa-youtube-square
           type: fontawesome
       launch_buttons:
-        binderhub_url: https://binder-staging.2i2c.cloud
+        binderhub_url: https://aws-uswest2-binder.pangeo.io/
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
Addresses https://github.com/ProjectPythiaCookbooks/projectpythiacookbooks.github.io/issues/85 for this repo.

For this one, since it seems to be [working for the Radar Cookbook](https://github.com/ProjectPythiaCookbooks/radar-cookbook/pull/63), I'm linking to the new Pangeo service at https://aws-uswest2-binder.pangeo.io/

My reasoning is that this Cookbook makes use of Dask to work with data stored on AWS.